### PR TITLE
fixes for Ship of Harkinian

### DIFF
--- a/ports/soh/Ship of Harkinian.sh
+++ b/ports/soh/Ship of Harkinian.sh
@@ -27,7 +27,7 @@ cd $GAMEDIR
 
 # Exports
 export LD_LIBRARY_PATH="$GAMEDIR/libs:/usr/lib":$LD_LIBRARY_PATH
-export SDL_GAMECONTROLLERCONFIG_FILE=$sdl_controllerconfig
+[-z "$sdl_controllerconfig" ] && export SDL_GAMECONTROLLERCONFIG=$sdl_controllerconfig
 
 # Permissions
 $ESUDO chmod 666 /dev/tty0

--- a/ports/soh/Ship of Harkinian.sh
+++ b/ports/soh/Ship of Harkinian.sh
@@ -27,7 +27,7 @@ cd $GAMEDIR
 
 # Exports
 export LD_LIBRARY_PATH="$GAMEDIR/libs:/usr/lib":$LD_LIBRARY_PATH
-[-z "$sdl_controllerconfig" ] && export SDL_GAMECONTROLLERCONFIG=$sdl_controllerconfig
+export SDL_GAMECONTROLLERCONFIG=$sdl_controllerconfig
 
 # Permissions
 $ESUDO chmod 666 /dev/tty0

--- a/ports/soh/Ship of Harkinian.sh
+++ b/ports/soh/Ship of Harkinian.sh
@@ -20,14 +20,14 @@ source $controlfolder/device_info.txt
 [ -f "${controlfolder}/mod_${CFW_NAME}.txt" ] && source "${controlfolder}/mod_${CFW_NAME}.txt"
 
 # Set variables
-GAMEDIR="$directory/ports/soh"
+GAMEDIR="/$directory/ports/soh"
 > "$GAMEDIR/log.txt" && exec > >(tee "$GAMEDIR/log.txt") 2>&1
 
 cd $GAMEDIR
 
 # Exports
 export LD_LIBRARY_PATH="$GAMEDIR/libs:/usr/lib":$LD_LIBRARY_PATH
-export SDL_GAMECONTROLLERCONFIG=$sdl_controllerconfig
+export SDL_GAMECONTROLLERCONFIG_FILE=$sdl_controllerconfig
 
 # Permissions
 $ESUDO chmod 666 /dev/tty0


### PR DESCRIPTION
**add leading slash to GAMEDIR**
before this fix the game did not launch

**SDL_GAMECONTROLLER_FILE instead of SDL_GAMECONTROLLER**
gptokeyb does not read SDL_GAMECONTROLLER env var, it is called SDL_GAMECONTROLLER_FILE, see gptokeyb.cpp
On my RG40XX H the controls were not assigned correctly without this change
