### PR TITLE
Render96ex: The very expected fix for 1:1 display (eg RGB30 and RG CUBE XX)

### DIFF
--- a/ports/render96ex/render96ex.sh
+++ b/ports/render96ex/render96ex.sh
@@ -122,6 +122,12 @@ $GPTOKEYB "sm64.us.f3dex2e.${DEVICE_ARCH}" &
 
 pm_platform_helper "$GAMEDIR/sm64.us.f3dex2e.${DEVICE_ARCH}"
 
+# 1:1 display hack
+if [[ ${DISPLAY_WIDTH} -eq ${DISPLAY_HEIGHT} ]]; then
+  grep "# patch for 1:1 display" "${GAMEDIR}/hacksdl.${ANALOG_STICKS}.conf" 2>&1 >/dev/null
+  [[ $? -eq 0 ]] || cat "${GAMEDIR}/hacksdl.${DISPLAY_WIDTH}x${DISPLAY_HEIGHT}.conf" >> "${GAMEDIR}/hacksdl.${ANALOG_STICKS}.conf"
+fi
+
 # use hacksdl to create a virtual analog stick from the dpad
 if [[ -f "${GAMEDIR}/hacksdl.${ANALOG_STICKS}.conf" ]]; then
   export LD_PRELOAD="hacksdl.so"

--- a/ports/render96ex/render96ex/hacksdl.720x720.conf
+++ b/ports/render96ex/render96ex/hacksdl.720x720.conf
@@ -1,0 +1,5 @@
+
+# patch for 1:1 display
+
+HACKSDL_GET_WINDOW_SIZE_W="720";
+HACKSDL_GET_WINDOW_SIZE_H="540";


### PR DESCRIPTION
Just a hack that avoids cropping the screen on 1:1 display devices. Not perfect but it's better than nothing.

It fixed issue [535](https://github.com/PortsMaster/PortMaster-New/issues/535)

![IMG_5076](https://github.com/user-attachments/assets/82da0c85-03ee-41d7-9465-a838a161d456)
