### PR TITLE
Harkinians: add hotkey controls for c buttons

### DIFF
--- a/ports/soh/soh/soh.gptk
+++ b/ports/soh/soh/soh.gptk
@@ -21,10 +21,16 @@ up = \"
 down = \"
 left = \"
 right = \"
+
 a = \"
+a_hk = right
 b = \"
+b_hk =down
 y = \"
+y_hk = left
 x = \"
+x_hk = up
+
 l1 = \"
 l2 = \"
 r1 = \"

--- a/ports/soh2/soh2/soh2.gptk
+++ b/ports/soh2/soh2/soh2.gptk
@@ -1,3 +1,19 @@
+###########################
+#DEFAULT KEYBOARD CONTROLS#
+###########################
+# A = X
+# B = C
+# L = E
+# R = R
+# Z = Z
+# D-PAD UP = T
+# D-PAD DOWN = G
+# D-PAD LEFT = F
+# D-PAD RIGHT = H
+# ANALOG = WASD
+# C-BUTTONS = UP/DOWN/LEFT/RIGHT
+# START = SPACE
+
 guide = f1
 back = \"
 start = \"
@@ -5,10 +21,16 @@ up = \"
 down = \"
 left = \"
 right = \"
+
 a = \"
+a_hk = right
 b = \"
+b_hk =down
 y = \"
+y_hk = left
 x = \"
+x_hk = up
+
 l1 = \"
 l2 = \"
 r1 = \"


### PR DESCRIPTION
This arrangement helps devices without a right analog stick, such as the RG35XXSP. Users with such devices can use `HOTKEY + ABXY` to toggle a C-Button. Tested and verified functional, and is also not invasive to users with analog sticks.