### PR TITLE
render96ex: fix r36s arkOS audio issue and use lower audio quality on 1GB devices to avoid crash

### DIFF
--- a/ports/render96ex/README.md
+++ b/ports/render96ex/README.md
@@ -32,10 +32,6 @@ This port comes with 3 optional packages:
 
 The extraction of the assets from the rom will temporary uses up to 1 GB of extra storage. Be sure to have at least this amount of free space before launching the game for the first time or it will fail.
 
-**If you are using muOS** you need at least the banana version to run this port.
-
-R36S with ArkOS can only run the game after disabling the audio pack, otherwise the game crashes just after launching it. To disable the audio pack rename the `audio` folder in `render96ex/dynos` to `audio.disable`. The game will run with limited sounds effects and no music.
-
 The Dynos 3D model pack is installed but not enabled by default because on most handheld the game will be choppy when combined with the 60 fps feature. You have to enable it in the dynos menu.
 
 The 60 fps feature is enabled by default. If your device can not handle it and the game is running choppy you can try to disable it in the display options in the option menu. Then wait few seconds to let the framerate stabilize.

--- a/ports/render96ex/render96ex.sh
+++ b/ports/render96ex/render96ex.sh
@@ -140,6 +140,12 @@ if [[ -f "${GAMEDIR}/hacksdl.${ANALOG_STICKS}.conf" ]]; then
   export HACKSDL_CONFIG_FILE="${GAMEDIR}/hacksdl.${ANALOG_STICKS}.conf"
 fi
 
+# Trick to get alsa dmix enabled on R36S with ArkOS
+# ~/.asoundrc is removed before and port is started
+# and put back after the port exits.
+# So we put it back
+[[ "$CFW_NAME" =~ ^ArkOS.* ]] && cp "${GAMEDIR}/asoundrc" "${HOME}/.asoundrc"
+
 ./sm64.us.f3dex2e.${DEVICE_ARCH} --savepath ./conf/
 
 pm_finish

--- a/ports/render96ex/render96ex/asoundrc
+++ b/ports/render96ex/render96ex/asoundrc
@@ -1,0 +1,22 @@
+pcm.!default {
+        type plug
+        slave.pcm "dmixer"
+}
+
+pcm.dmixer  {
+ type dmix
+ ipc_key 1024
+ slave {
+  pcm "hw:0,0"
+  period_time 0
+  period_size 1024
+  buffer_size 4096
+  rate 44100
+ }
+bindings {
+ 0 0
+ 1 1
+ }
+}
+
+ctl.!default { type hw card 0 }

--- a/ports/render96ex/render96ex/tools/install_mario64
+++ b/ports/render96ex/render96ex/tools/install_mario64
@@ -227,7 +227,14 @@ do
       rm -f mp3.nok
       find . -iname '*.txt' -exec cp {} "${GAMEDIR}/${DYNOS_DIR}/${dynospack}/{}" \;
       find . -type d -exec mkdir -p "${GAMEDIR}/${DYNOS_DIR}/${dynospack}/{}" \;
-      find . -iname '*.mp3' -exec sh -c 'mpg123 -q -w "$2/${1%.*}.wav" "$1" || touch mp3.nok' sh {} "${GAMEDIR}/${DYNOS_DIR}/${dynospack}" \;
+
+      if [[ "$DEVICE_RAM" -lt "2" ]]; then
+        # on 1GB device use lower audio quality to avoid a crash
+        # with CFW that don't have swap or zram
+      	find . -iname '*.mp3' -exec sh -c 'mpg123 -2 -q -w "$2/${1%.*}.wav" "$1" || touch mp3.nok' sh {} "${GAMEDIR}/${DYNOS_DIR}/${dynospack}" \;
+      else
+      	find . -iname '*.mp3' -exec sh -c 'mpg123 -q -w "$2/${1%.*}.wav" "$1" || touch mp3.nok' sh {} "${GAMEDIR}/${DYNOS_DIR}/${dynospack}" \;
+      fi
       
       if [ -f "mp3.nok" ]
       then


### PR DESCRIPTION
Finally I found how to get it working on R36S with ArkOS !