### PR TITLE
Add executable permissions to Spaghettify binary

### DIFF
--- a/ports/spaghettikart/SpaghettiKart.sh
+++ b/ports/spaghettikart/SpaghettiKart.sh
@@ -63,6 +63,8 @@ else
   cp bin/Spaghettify-GLES ./Spaghettify
 fi
 
+$ESUDO chmod +x ./Spaghettify
+
 $GPTOKEYB "$BINARY" -c "$BINARY.gptk" &
 
 pm_platform_helper "$GAMEDIR/$BINARY"


### PR DESCRIPTION
# Fix for SpaguettiKart

## Bug description

When I start the game, I get this log.
Looking at scripts from other ports such as Starship, I realized that I needed to assign execution permissions.

OpenGL version string: 3.1 Mesa 24.3.4
/storage/roms/ports/SpaghettiKart.sh: line 84: ./Spaghettify: Permission denied
sway is not running, exiting
[GPTK]: Running in UINPUT output mode.
[GPTK]: Running in Fake Keyboard mode
[GPTK]: Using ConfigFile Spaghettify.gptk
[GPTK]: Joystick 0 has game controller name 'H700 Gamepad'

## Game Information
- **Title**: SpaguettiKart
- **URL**: https://github.com/HarbourMasters/SpaghettiKart/tree/main

## Submission Requirements

### CFW Tests
Ensure your game has been tested on all major CFWs:
- [ ] AmberELEC
- [ ] ArkOS
- [x] ROCKNIX
- [ ] muOS

### Resolution Tests
Test all major resolutions:
- [ ] 480x320
- [ ] 640x480
- [ ] 720x720 (RGB30)
- [ ] Higher resolutions (e.g., 1280x720)

## File Structure
- Your port should have the following structure:
  - portname/
    - port.json
    - README.md
    - screenshot.jpg
    - cover.jpg
    - gameinfo.xml
    - Port Name.sh
    - portname/
      - <portfiles here>

## Additional Resources
For an in-depth guide on creating a pull request, refer to: [PortMaster Game Packaging Guide](https://portmaster.games/packaging.html#creating-a-pull-request)
